### PR TITLE
Added ENUM roots: enumer+nrenum, deleted dead e164.org

### DIFF
--- a/src/org/lumicall/android/db/ENUMSuffix.java
+++ b/src/org/lumicall/android/db/ENUMSuffix.java
@@ -17,7 +17,8 @@ public class ENUMSuffix extends DBObject implements Comparable<ENUMSuffix> {
 			new String[] {
 				"e164.arpa",
 				"e164-addr.sip5060.net",
-				"e164.org"
+                                "enum.enumer.org",
+                                "nrenum.net"
 	};
 	
 	private final static String DB_TABLE = "ENUMSuffix";


### PR DESCRIPTION
I updated ENUM roots:
 - Deleted out-of-service e164.org
 - Added two actual working ENUM roots:
 a) ENUMER - decentralized blockchain-based ENUM: http://enumer.org/
 b) Nrenum - ENUM services for academia: https://nrenum.net/

ENUMER architecture described here: 
https://medium.com/@emer.tech/voip-made-free-with-blockchain-introducing-enumer-35235c4abec5
